### PR TITLE
perf(codex): reduce streaming allocation churn

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1372,6 +1372,20 @@ func (e *CodexExecutor) executeCompact(ctx context.Context, auth *cliproxyauth.A
 	return resp, nil
 }
 
+func canTranslateCodexStreamLineWithoutClone(upstream, downstream sdktranslator.Format) bool {
+	// Response transformers are registered under the request direction (downstream, upstream).
+	return upstream == sdktranslator.FormatCodex &&
+		downstream == sdktranslator.FormatClaude &&
+		sdktranslator.HasStreamResponseTransformer(downstream, upstream)
+}
+
+func codexStreamLineForTranslation(line []byte, useDirect bool) []byte {
+	if useDirect {
+		return line
+	}
+	return bytes.Clone(line)
+}
+
 func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Auth, req cliproxyexecutor.Request, opts cliproxyexecutor.Options) (_ *cliproxyexecutor.StreamResult, err error) {
 	if opts.Alt == "responses/compact" {
 		return nil, statusErr{code: http.StatusBadRequest, msg: "streaming not supported for /responses/compact"}
@@ -1439,7 +1453,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		authLabel = auth.Label
 		authType, authValue = auth.AccountInfo()
 	}
-	helps.RecordAPIRequest(ctx, e.cfg, helps.UpstreamRequestLog{
+	helps.RecordAPIRequestWithImmutableBody(ctx, e.cfg, helps.UpstreamRequestLog{
 		URL:       url,
 		Method:    http.MethodPost,
 		Headers:   httpReq.Header.Clone(),
@@ -1477,6 +1491,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		err = newCodexStatusErr(httpResp.StatusCode, data)
 		return nil, err
 	}
+	canTranslateStreamLineWithoutClone := canTranslateCodexStreamLineWithoutClone(to, responseFormat)
 	out := make(chan cliproxyexecutor.StreamChunk)
 	go func() {
 		defer close(out)
@@ -1493,7 +1508,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		for scanner.Scan() {
 			line := applyCodexIdentityConfuseResponsePayload(scanner.Bytes(), identityState)
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
-			translatedLine := bytes.Clone(line)
+			translatedLine := codexStreamLineForTranslation(line, canTranslateStreamLineWithoutClone)
 			terminalSuccess := false
 
 			if bytes.HasPrefix(line, dataTag) {

--- a/internal/runtime/executor/codex_executor_performance_test.go
+++ b/internal/runtime/executor/codex_executor_performance_test.go
@@ -1,0 +1,152 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/router-for-me/CLIProxyAPI/v7/internal/config"
+	_ "github.com/router-for-me/CLIProxyAPI/v7/internal/translator"
+	cliproxyauth "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/auth"
+	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	sdktranslator "github.com/router-for-me/CLIProxyAPI/v7/sdk/translator"
+)
+
+func BenchmarkCodexExecuteStreamDeferredRequestCapture(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	for _, size := range []int{64 << 10, 1 << 20, 8 << 20} {
+		b.Run(byteSizeName(size), func(b *testing.B) {
+			payload := benchmarkClaudeRequest(b, size)
+			stream := benchmarkCodexStream(1)
+			executor := NewCodexExecutor(&config.Config{})
+			auth := benchmarkCodexAuth()
+			request := cliproxyexecutor.Request{Model: "gpt-5.6-sol", Payload: payload}
+			options := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude, Stream: true}
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(payload)))
+			b.ResetTimer()
+			for b.Loop() {
+				ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+				ctx := benchmarkCodexContext(stream)
+				ctx = context.WithValue(ctx, "gin", ginCtx)
+				benchmarkDrainCodexStream(b, executor, ctx, auth, request, options)
+			}
+		})
+	}
+}
+
+func BenchmarkCodexExecuteStreamClaudeSSE(b *testing.B) {
+	payload := benchmarkClaudeRequest(b, 256)
+	executor := NewCodexExecutor(&config.Config{})
+	auth := benchmarkCodexAuth()
+	request := cliproxyexecutor.Request{Model: "gpt-5.6-sol", Payload: payload}
+	options := cliproxyexecutor.Options{SourceFormat: sdktranslator.FormatClaude, Stream: true}
+
+	for _, eventCount := range []int{1, 100, 1000} {
+		b.Run("Events"+strconv.Itoa(eventCount), func(b *testing.B) {
+			stream := benchmarkCodexStream(eventCount)
+			b.ReportAllocs()
+			b.SetBytes(int64(len(stream)))
+			b.ResetTimer()
+			for b.Loop() {
+				benchmarkDrainCodexStream(b, executor, benchmarkCodexContext(stream), auth, request, options)
+			}
+		})
+	}
+}
+
+func benchmarkClaudeRequest(b *testing.B, contentSize int) []byte {
+	b.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"model":      "claude-fable-5",
+		"stream":     true,
+		"max_tokens": 64,
+		"messages": []map[string]any{{
+			"role":    "user",
+			"content": strings.Repeat("a", contentSize),
+		}},
+	})
+	if err != nil {
+		b.Fatalf("marshal benchmark request: %v", err)
+	}
+	return payload
+}
+
+func benchmarkCodexStream(eventCount int) []byte {
+	var stream bytes.Buffer
+	stream.WriteString("data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_bench\",\"model\":\"gpt-5.6-sol\"}}\n")
+	for range eventCount {
+		stream.WriteString("data: {\"type\":\"response.output_text.delta\",\"delta\":\"benchmark token\"}\n")
+	}
+	stream.WriteString("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_bench\",\"model\":\"gpt-5.6-sol\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":8,\"output_tokens\":16,\"total_tokens\":24}}}\n")
+	return stream.Bytes()
+}
+
+func benchmarkCodexAuth() *cliproxyauth.Auth {
+	return &cliproxyauth.Auth{
+		ID: "benchmark-auth",
+		Attributes: map[string]string{
+			"base_url": "http://codex.test",
+			"api_key":  "test",
+		},
+	}
+}
+
+func benchmarkCodexContext(stream []byte) context.Context {
+	return context.WithValue(context.Background(), "cliproxy.roundtripper", benchmarkRoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if _, err := io.Copy(io.Discard, req.Body); err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"text/event-stream"}},
+			Body:       io.NopCloser(bytes.NewReader(stream)),
+			Request:    req,
+		}, nil
+	}))
+}
+
+func benchmarkDrainCodexStream(
+	b *testing.B,
+	executor *CodexExecutor,
+	ctx context.Context,
+	auth *cliproxyauth.Auth,
+	request cliproxyexecutor.Request,
+	options cliproxyexecutor.Options,
+) {
+	b.Helper()
+	result, err := executor.ExecuteStream(ctx, auth, request, options)
+	if err != nil {
+		b.Fatalf("ExecuteStream: %v", err)
+	}
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			b.Fatalf("stream chunk: %v", chunk.Err)
+		}
+	}
+}
+
+type benchmarkRoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f benchmarkRoundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func byteSizeName(size int) string {
+	switch {
+	case size%(1<<20) == 0:
+		return strconv.Itoa(size/(1<<20)) + "MiB"
+	case size%(1<<10) == 0:
+		return strconv.Itoa(size/(1<<10)) + "KiB"
+	default:
+		return strconv.Itoa(size) + "B"
+	}
+}

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -529,6 +529,112 @@ func TestCodexTerminalStreamErrHandlesUsageLimitResponseFailed(t *testing.T) {
 	}
 }
 
+func TestCodexExecutorExecuteStreamFallbackChunksSurviveScannerReuse(t *testing.T) {
+	created := []byte(`data: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5.6-sol"}}`)
+	completed := []byte(`data: {"type":"response.completed","response":{"id":"resp_1","model":"gpt-5.6-sol","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`)
+	stream := append(append(append([]byte{}, created...), '\n'), completed...)
+	stream = append(stream, '\n')
+	ctx := context.WithValue(context.Background(), "cliproxy.roundtripper", roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": {"text/event-stream"}},
+			Body:       io.NopCloser(bytes.NewReader(stream)),
+			Request:    req,
+		}, nil
+	}))
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": "http://codex.test",
+		"api_key":  "test",
+	}}
+	result, err := executor.ExecuteStream(ctx, auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.6-sol",
+		Payload: []byte(`{"model":"gpt-5.6-sol","input":"hello"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat:   sdktranslator.FormatCodex,
+		ResponseFormat: sdktranslator.FormatCodex,
+		Stream:         true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var payloads [][]byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		payloads = append(payloads, chunk.Payload)
+	}
+	if len(payloads) != 2 {
+		t.Fatalf("payload count = %d, want 2", len(payloads))
+	}
+	if !bytes.Equal(payloads[0], created) {
+		t.Fatalf("first fallback payload changed after scanner reuse: got %q want %q", payloads[0], created)
+	}
+}
+
+func TestCodexStreamLineForTranslationOwnership(t *testing.T) {
+	line := []byte("data: benchmark")
+	cloned := codexStreamLineForTranslation(line, false)
+	line[0] = 'X'
+	if cloned[0] == 'X' {
+		t.Fatal("fallback translation input aliases scanner buffer")
+	}
+
+	direct := codexStreamLineForTranslation(line, true)
+	direct[0] = 'Y'
+	if line[0] != 'Y' {
+		t.Fatal("native translation input should reuse scanner buffer")
+	}
+}
+
+func TestCodexToClaudeStreamTranslationDetachesOutput(t *testing.T) {
+	if !canTranslateCodexStreamLineWithoutClone(sdktranslator.FormatCodex, sdktranslator.FormatClaude) {
+		t.Fatal("native Codex-to-Claude stream transformer is not registered")
+	}
+	input := []byte(`data: {"type":"response.output_text.delta","delta":"hello"}`)
+	var param any
+	chunks := sdktranslator.TranslateStream(
+		context.Background(),
+		sdktranslator.FormatCodex,
+		sdktranslator.FormatClaude,
+		"gpt-5.6-sol",
+		[]byte(`{"messages":[]}`),
+		nil,
+		input,
+		&param,
+	)
+	if len(chunks) == 0 {
+		t.Fatal("native Codex-to-Claude stream transformer returned no chunks")
+	}
+	want := make([][]byte, len(chunks))
+	for i := range chunks {
+		want[i] = bytes.Clone(chunks[i])
+	}
+	for i := range input {
+		input[i] = 'X'
+	}
+	for i := range chunks {
+		if !bytes.Equal(chunks[i], want[i]) {
+			t.Fatalf("translated chunk %d changed after input reuse: got %q want %q", i, chunks[i], want[i])
+		}
+	}
+}
+
+func TestCanTranslateCodexStreamLineWithoutCloneRejectsFallbackFormats(t *testing.T) {
+	for _, downstream := range []sdktranslator.Format{
+		sdktranslator.FormatCodex,
+		sdktranslator.FormatOpenAI,
+		sdktranslator.FormatOpenAIResponse,
+	} {
+		if canTranslateCodexStreamLineWithoutClone(sdktranslator.FormatCodex, downstream) {
+			t.Fatalf("downstream format %q must retain defensive clone", downstream)
+		}
+	}
+}
+
 func statusCodeFromTestError(t *testing.T, err error) int {
 	t.Helper()
 

--- a/internal/runtime/executor/helps/logging_helpers.go
+++ b/internal/runtime/executor/helps/logging_helpers.go
@@ -62,6 +62,17 @@ func requestLogCaptureEnabled(cfg *config.Config) bool {
 
 // RecordAPIRequest stores the upstream request metadata in Gin context for request logging.
 func RecordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequestLog) {
+	recordAPIRequest(ctx, cfg, info, true)
+}
+
+// RecordAPIRequestWithImmutableBody stores request metadata without cloning Body
+// when request logging is disabled. The caller must not mutate Body until the
+// request has finished and deferred error logging can no longer consume it.
+func RecordAPIRequestWithImmutableBody(ctx context.Context, cfg *config.Config, info UpstreamRequestLog) {
+	recordAPIRequest(ctx, cfg, info, false)
+}
+
+func recordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequestLog, cloneDeferredBody bool) {
 	if cfg == nil || cfg.CommercialMode {
 		return
 	}
@@ -70,7 +81,7 @@ func RecordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequ
 		return
 	}
 	if !cfg.RequestLog {
-		deferAPIRequest(ginCtx, info)
+		deferAPIRequest(ginCtx, info, cloneDeferredBody)
 		return
 	}
 
@@ -124,7 +135,7 @@ func RecordAPIRequest(ctx context.Context, cfg *config.Config, info UpstreamRequ
 	}
 }
 
-func deferAPIRequest(ginCtx *gin.Context, info UpstreamRequestLog) {
+func deferAPIRequest(ginCtx *gin.Context, info UpstreamRequestLog, cloneBody bool) {
 	if ginCtx == nil {
 		return
 	}
@@ -145,7 +156,10 @@ func deferAPIRequest(ginCtx *gin.Context, info UpstreamRequestLog) {
 	if captureLength > remaining {
 		captureLength = remaining
 	}
-	capturedInfo.Body = bytes.Clone(info.Body[:captureLength])
+	capturedInfo.Body = info.Body[:captureLength]
+	if cloneBody {
+		capturedInfo.Body = bytes.Clone(capturedInfo.Body)
+	}
 	bodyEmpty := len(info.Body) == 0
 	bodyTruncated := captureLength < len(info.Body)
 	ginCtx.Set(deferredAPIRequestBytesKey, bytesUsed+captureLength)

--- a/internal/runtime/executor/helps/logging_helpers_test.go
+++ b/internal/runtime/executor/helps/logging_helpers_test.go
@@ -40,6 +40,73 @@ func TestRecordAPIRequestClonesDeferredBodyWhenRequestLogDisabled(t *testing.T) 
 	}
 }
 
+func TestRecordAPIRequestWithImmutableBodyRetainsBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ctx := context.WithValue(context.Background(), "gin", ginCtx)
+	body := []byte(`{"model":"original"}`)
+
+	RecordAPIRequestWithImmutableBody(ctx, &config.Config{}, UpstreamRequestLog{
+		URL:    "https://api.example.com/v1/responses",
+		Method: http.MethodPost,
+		Body:   body,
+	})
+	// Deliberately violate the caller contract to prove this path retains rather than clones Body.
+	body[10] = 'X'
+
+	captured := deferredAPIRequestAt(t, ginCtx, 0)
+	if !strings.Contains(captured, `{"model":"Xriginal"}`) {
+		t.Fatalf("captured API request = %q, want retained immutable body", captured)
+	}
+}
+
+func TestRecordAPIRequestWithImmutableBodyPreservesEmptyAndTruncatedBodies(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("empty", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(recorder)
+		ctx := context.WithValue(context.Background(), "gin", ginCtx)
+
+		RecordAPIRequestWithImmutableBody(ctx, &config.Config{}, UpstreamRequestLog{})
+
+		if captured := deferredAPIRequestAt(t, ginCtx, 0); !strings.Contains(captured, "Body:\n<empty>") {
+			t.Fatalf("captured API request = %q, want empty body marker", captured)
+		}
+	})
+
+	t.Run("truncated", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(recorder)
+		ginCtx.Set(deferredAPIRequestBytesKey, maxDeferredAPIRequestBodyBytes-4)
+		ctx := context.WithValue(context.Background(), "gin", ginCtx)
+
+		RecordAPIRequestWithImmutableBody(ctx, &config.Config{}, UpstreamRequestLog{Body: []byte("12345678")})
+
+		captured := deferredAPIRequestAt(t, ginCtx, 0)
+		if !strings.Contains(captured, "Body:\n1234\n[API REQUEST BODY TRUNCATED: captured first 4 bytes]") {
+			t.Fatalf("captured API request = %q, want four-byte truncation", captured)
+		}
+		if got, _ := ginCtx.Get(deferredAPIRequestBytesKey); got != maxDeferredAPIRequestBodyBytes {
+			t.Fatalf("captured bytes = %v, want %d", got, maxDeferredAPIRequestBodyBytes)
+		}
+	})
+}
+
+func deferredAPIRequestAt(t *testing.T, ginCtx *gin.Context, index int) string {
+	t.Helper()
+	value, exists := ginCtx.Get(logging.DeferredAPIRequestContextKey)
+	if !exists {
+		t.Fatal("deferred API request was not captured")
+	}
+	requests, ok := value.([]logging.DeferredAPIRequest)
+	if !ok || len(requests) <= index {
+		t.Fatalf("deferred API requests = %#v, want index %d", value, index)
+	}
+	return string(requests[index]())
+}
+
 func TestRecordAPIResponseMetadataStoresHeadersWhenRequestLogDisabled(t *testing.T) {
 	ctx := logging.WithResponseHeadersHolder(context.Background())
 	headers := http.Header{}


### PR DESCRIPTION
## What Problem This Solves

The Claude-to-Codex streaming path performs two avoidable copies under large Clawdex workloads:

- deferred error logging clones up to 32 MiB of the finalized upstream request even though the Codex streaming caller no longer mutates it;
- every Codex SSE scanner line is cloned before the native Codex-to-Claude transformer consumes it synchronously.

These copies add allocation and garbage-collection pressure on the centralized Gorilla gateway.

## Why This Change Was Made

- Add a narrow immutable-body logging API while preserving the existing snapshotting API and its mutation guarantee for general callers.
- Use the immutable path only for the finalized Codex streaming request body.
- Reuse scanner bytes only when the registered native Codex-to-Claude transformer is present.
- Preserve defensive cloning for fallback and non-Claude response formats.
- Add network-free benchmarks and ownership regression tests.

No files under `internal/translator/` are changed.

## User Impact

Protocol behavior and deferred error diagnostics are unchanged. Under the measured hot paths:

- large request benchmarks allocate 6.1–6.3% fewer bytes per operation;
- 100-event Claude SSE translation is 4.3% faster, with 4.8% fewer bytes and 5.3% fewer allocations;
- 1,000-event Claude SSE translation is 3.5% faster, with 5.6% fewer bytes and 5.8% fewer allocations;
- request-path latency is statistically unchanged.

## Evidence

Validation:

```text
go test ./...
go build -o /tmp/cliproxy-test-output ./cmd/server
go test -race ./internal/runtime/executor/helps -run '^TestRecordAPIRequest'
go test -race ./internal/runtime/executor -run '^(TestCodexExecutorExecuteStreamFallbackChunksSurviveScannerReuse|TestCodexStreamLineForTranslationOwnership|TestCodexToClaudeStreamTranslationDetachesOutput|TestCanTranslateCodexStreamLineWithoutCloneRejectsFallbackFormats)$'
```

Existing translator and executor-helper benchmark controls passed unchanged.

Benchmark comparison used fresh `origin/main` and candidate builds back-to-back on the same Apple M3 Ultra with `GOMAXPROCS=1`, `-benchtime=500ms`, and `-count=10`.

Autoreview: clean, patch correct at 0.91 confidence with no accepted/actionable findings.

Known unrelated issue: broad `go test -race ./internal/runtime/executor` exposes an existing Antigravity test-cleanup race on current main. That race is not touched here and will be fixed in a separate test-only PR.
