### PR TITLE
test(antigravity): join credit refresh cleanup

### DIFF
--- a/internal/runtime/executor/antigravity_executor_credits_test.go
+++ b/internal/runtime/executor/antigravity_executor_credits_test.go
@@ -21,6 +21,15 @@ import (
 )
 
 func resetAntigravityCreditsRetryState() {
+	antigravityCreditsHintRefreshByID.Range(func(_, value any) bool {
+		state, ok := value.(*antigravityCreditsHintRefreshState)
+		if !ok || state == nil {
+			return true
+		}
+		state.mu.Lock()
+		state.mu.Unlock()
+		return true
+	})
 	antigravityCreditsFailureByAuth = sync.Map{}
 	antigravityShortCooldownByAuth = sync.Map{}
 	antigravityCreditsBalanceByAuth = sync.Map{}


### PR DESCRIPTION
## What Problem This Solves

`go test -race ./internal/runtime/executor` reports races between Antigravity test cleanup replacing package-global `sync.Map` values and detached warm-token credit-refresh workers still storing or deleting entries.

The tests observed an intermediate credits hint but did not join the worker before cleanup.

## Why This Change Was Made

The test-only reset helper now traverses registered per-auth refresh states and locks/unlocks each state's existing mutex before replacing the global maps. That mutex is held from refresh admission until the worker completes all writes and deferred cleanup.

This makes the reset a deterministic lifecycle boundary for every Antigravity credits test without changing production behavior.

## User Impact

None. Only `_test.go` code changes.

## Evidence

```text
go test -race ./internal/runtime/executor -run '^TestEnsureAccessToken_WarmTokenLoadsCreditsHint$' -count=50
go test -race ./internal/runtime/executor
go test ./...
go build -o /tmp/cliproxy-race-test-output ./cmd/server
git diff --check
```

All commands passed. The final diff contains only `internal/runtime/executor/antigravity_executor_credits_test.go`.

Autoreview: clean, patch correct at 0.86 confidence with no accepted/actionable findings.
