### PR TITLE
fix(claude): request-fidelity follow-ups — exact media token counting, fallback replay boundary, Gemini error channel

### DIFF
--- a/internal/runtime/executor/codex_executor.go
+++ b/internal/runtime/executor/codex_executor.go
@@ -1649,21 +1649,57 @@ func (e *CodexExecutor) CountTokens(ctx context.Context, auth *cliproxyauth.Auth
 	}
 
 	body = helps.SetStringIfDifferent(body, "model", baseModel)
-	body, _ = sjson.DeleteBytes(body, "previous_response_id")
-	body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
-	body, _ = sjson.DeleteBytes(body, "safety_identifier")
-	body, _ = sjson.DeleteBytes(body, "stream_options")
-	body = helps.SetBoolIfDifferent(body, "stream", false)
 	body = normalizeCodexInstructions(body)
-
-	enc, err := tokenizerForCodexModel(baseModel)
-	if err != nil {
-		return cliproxyexecutor.Response{}, fmt.Errorf("codex executor: tokenizer init failed: %w", err)
+	// Server-side history (conversation/previous_response_id) prepends context
+	// the local tokenizer cannot see, so it forces the remote counter just
+	// like inline media does. Decide before the local-path cleanup deletes it.
+	// These are nullable request fields: an explicit null key is inactive, so
+	// presence checks must be null-aware.
+	fieldActive := func(path string) bool {
+		value := gjson.GetBytes(body, path)
+		return value.Exists() && value.Type != gjson.Null
+	}
+	stateful := fieldActive("previous_response_id") || fieldActive("conversation")
+	// Reusable prompt templates resolve server-side and the count endpoint has
+	// no prompt parameter, so neither counting path can price them.
+	if fieldActive("prompt") {
+		return cliproxyexecutor.Response{}, &cliproxyexecutor.RequestError{
+			HTTPStatus: http.StatusBadRequest,
+			Code:       "invalid_request_error",
+			Message:    "routed token counting does not support reusable prompt templates",
+		}
 	}
 
-	count, err := countCodexInputTokens(enc, body)
-	if err != nil {
-		return cliproxyexecutor.Response{}, fmt.Errorf("codex executor: token counting failed: %w", err)
+	var count int64
+	if stateful || codexInputHasMediaParts(body) {
+		// Local tokenizers cannot price media (image tiling, PDF text plus page
+		// images), so media payloads count through the exact provider endpoint.
+		// Only API-key auths with a platform base URL are proven to expose
+		// /responses/input_tokens; the ChatGPT Codex backend stays fail-closed.
+		apiKey, baseURL := codexCreds(auth)
+		if strings.TrimSpace(baseURL) == "" {
+			return cliproxyexecutor.Response{}, errCodexTokenCountMediaUnsupported()
+		}
+		remoteCount, errRemote := countCodexInputTokensRemote(ctx, e.cfg, auth, apiKey, baseURL, body)
+		if errRemote != nil {
+			return cliproxyexecutor.Response{}, errRemote
+		}
+		count = remoteCount
+	} else {
+		body, _ = sjson.DeleteBytes(body, "previous_response_id")
+		body, _ = sjson.DeleteBytes(body, "prompt_cache_retention")
+		body, _ = sjson.DeleteBytes(body, "safety_identifier")
+		body, _ = sjson.DeleteBytes(body, "stream_options")
+		body = helps.SetBoolIfDifferent(body, "stream", false)
+		enc, errEnc := tokenizerForCodexModel(baseModel)
+		if errEnc != nil {
+			return cliproxyexecutor.Response{}, fmt.Errorf("codex executor: tokenizer init failed: %w", errEnc)
+		}
+		localCount, errCount := countCodexInputTokens(enc, body)
+		if errCount != nil {
+			return cliproxyexecutor.Response{}, fmt.Errorf("codex executor: token counting failed: %w", errCount)
+		}
+		count = localCount
 	}
 
 	usageJSON := fmt.Sprintf(`{"response":{"usage":{"input_tokens":%d,"output_tokens":0,"total_tokens":%d}}}`, count, count)
@@ -1691,6 +1727,121 @@ func tokenizerForCodexModel(model string) (tokenizer.Codec, error) {
 	}
 }
 
+func errCodexTokenCountMediaUnsupported() *cliproxyexecutor.RequestError {
+	return &cliproxyexecutor.RequestError{
+		HTTPStatus: http.StatusBadRequest,
+		Code:       "invalid_request_error",
+		Message:    "routed token counting does not support image or document inputs for this credential",
+	}
+}
+
+// codexInputItemIsMessage accepts both tagged message items and the Responses
+// input union's type-less role/content form.
+func codexInputItemIsMessage(item gjson.Result) bool {
+	switch item.Get("type").String() {
+	case "message":
+		return true
+	case "":
+		return item.Get("role").Exists() && item.Get("content").Exists()
+	}
+	return false
+}
+
+// codexInputHasMediaParts mirrors the content shapes countCodexInputTokens
+// walks: message content parts and function_call_output output arrays.
+func codexInputHasMediaParts(body []byte) bool {
+	found := false
+	scanParts := func(content gjson.Result) {
+		if !content.IsArray() || found {
+			return
+		}
+		content.ForEach(func(_, part gjson.Result) bool {
+			switch part.Get("type").String() {
+			case "input_image", "input_file":
+				found = true
+				return false
+			}
+			return true
+		})
+	}
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return false
+	}
+	input.ForEach(func(_, item gjson.Result) bool {
+		// Scan every item's part-bearing fields regardless of item type so new
+		// union members cannot smuggle media past the exact remote counter;
+		// over-detection is safe because the endpoint accepts the full union.
+		scanParts(item.Get("content"))
+		scanParts(item.Get("output"))
+		// Item-level media shapes: computer screenshots, code-interpreter image
+		// outputs, and generated-image results are all provider-priced media.
+		if item.Get("output.type").String() == "computer_screenshot" {
+			found = true
+		}
+		if item.Get("type").String() == "image_generation_call" && item.Get("result").String() != "" {
+			found = true
+		}
+		if outputs := item.Get("outputs"); outputs.IsArray() {
+			outputs.ForEach(func(_, out gjson.Result) bool {
+				if out.Get("type").String() == "image" {
+					found = true
+					return false
+				}
+				return true
+			})
+		}
+		return !found
+	})
+	return found
+}
+
+// countCodexInputTokensRemote asks POST {base}/responses/input_tokens for the
+// exact count. The endpoint accepts the same input shape as Responses create.
+func countCodexInputTokensRemote(ctx context.Context, cfg *config.Config, auth *cliproxyauth.Auth, apiKey, baseURL string, body []byte) (int64, error) {
+	// The endpoint's schema is narrower than Responses create and 400s on
+	// create-only options, so project the payload onto its input-shaping
+	// fields instead of blacklisting knobs.
+	payload := []byte(`{}`)
+	// conversation/previous_response_id extend the counted context server-side
+	// and are part of the endpoint schema; dropping them would undercount.
+	for _, path := range []string{"model", "instructions", "input", "tools", "tool_choice", "parallel_tool_calls", "conversation", "previous_response_id", "reasoning", "text", "truncation", "personality"} {
+		if value := gjson.GetBytes(body, path); value.Exists() {
+			payload, _ = sjson.SetRawBytes(payload, path, []byte(value.Raw))
+		}
+	}
+	url := strings.TrimSuffix(baseURL, "/") + "/responses/input_tokens"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return 0, fmt.Errorf("codex executor: token count request failed: %w", err)
+	}
+	// Reuse the standard credential/header injection so configured overrides
+	// (organization/project/routing headers) reach the count endpoint too.
+	applyCodexHeaders(httpReq, auth, apiKey, false, cfg)
+	httpClient := helps.NewUtlsHTTPClient(ctx, cfg, auth, 0)
+	httpResp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return 0, fmt.Errorf("codex executor: token count request failed: %w", err)
+	}
+	defer func() {
+		if errClose := httpResp.Body.Close(); errClose != nil {
+			log.Errorf("codex executor: close token count response body error: %v", errClose)
+		}
+	}()
+	data, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return 0, fmt.Errorf("codex executor: token count response read failed: %w", err)
+	}
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return 0, newCodexStatusErr(httpResp.StatusCode, data)
+	}
+	tokens := gjson.GetBytes(data, "input_tokens")
+	if !tokens.Exists() {
+		return 0, fmt.Errorf("codex executor: token count response missing input_tokens")
+	}
+	return tokens.Int(), nil
+}
+
 func countCodexInputTokens(enc tokenizer.Codec, body []byte) (int64, error) {
 	if enc == nil {
 		return 0, fmt.Errorf("encoder is nil")
@@ -1711,15 +1862,9 @@ func countCodexInputTokens(enc tokenizer.Codec, body []byte) (int64, error) {
 			part := parts[i]
 			switch part.Get("type").String() {
 			case "input_image", "input_file":
-				// Media token cost is model- and content-dependent (image tiling,
-				// PDF text plus page images); any local heuristic under- or
-				// overreports badly. Fail request-scoped until counting routes
-				// through the exact POST /v1/responses/input_tokens endpoint.
-				return &cliproxyexecutor.RequestError{
-					HTTPStatus: http.StatusBadRequest,
-					Code:       "invalid_request_error",
-					Message:    "routed token counting does not support image or document inputs",
-				}
+				// Backstop: CountTokens routes media payloads to the exact
+				// provider endpoint before reaching this local tokenizer path.
+				return errCodexTokenCountMediaUnsupported()
 			default:
 				if text := strings.TrimSpace(part.Get("text").String()); text != "" {
 					segments = append(segments, text)
@@ -1739,11 +1884,20 @@ func countCodexInputTokens(enc tokenizer.Codec, body []byte) (int64, error) {
 		for i := range arr {
 			item := arr[i]
 			structuralTokens += 4
-			switch item.Get("type").String() {
-			case "message":
-				if err := appendContentParts(item.Get("content")); err != nil {
+			if codexInputItemIsMessage(item) {
+				content := item.Get("content")
+				if content.Type == gjson.String {
+					if text := strings.TrimSpace(content.String()); text != "" {
+						segments = append(segments, text)
+					}
+					continue
+				}
+				if err := appendContentParts(content); err != nil {
 					return 0, err
 				}
+				continue
+			}
+			switch item.Get("type").String() {
 			case "function_call":
 				if name := strings.TrimSpace(item.Get("name").String()); name != "" {
 					segments = append(segments, name)

--- a/internal/runtime/executor/codex_executor_token_count_test.go
+++ b/internal/runtime/executor/codex_executor_token_count_test.go
@@ -1,11 +1,15 @@
 package executor
 
 import (
+	"context"
 	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	"github.com/tidwall/gjson"
 	"github.com/tiktoken-go/tokenizer"
 )
 
@@ -36,6 +40,118 @@ func TestCountCodexInputTokensCountsTextAndStructure(t *testing.T) {
 		t.Fatalf("tokenizer: %v", err)
 	}
 	count, errCount := countCodexInputTokens(enc, []byte(`{"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"describe"}]}]}`))
+	if errCount != nil {
+		t.Fatalf("count: %v", errCount)
+	}
+	if count <= 0 {
+		t.Fatalf("count = %d, want positive", count)
+	}
+}
+
+func TestCodexInputHasMediaParts(t *testing.T) {
+	cases := []struct {
+		payload string
+		want    bool
+	}{
+		{`{"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}]}`, false},
+		{`{"input":[{"type":"message","role":"user","content":[{"type":"input_image","image_url":"data:image/png;base64,AA=="}]}]}`, true},
+		{`{"input":[{"type":"message","role":"user","content":[{"type":"input_file","file_url":"https://example.com/a.pdf"}]}]}`, true},
+		{`{"input":[{"type":"function_call_output","call_id":"c","output":[{"type":"input_file","file_data":"data:application/pdf;base64,AA=="}]}]}`, true},
+		{`{"input":[{"type":"function_call_output","call_id":"c","output":"plain text"}]}`, false},
+		{`{"input":[{"role":"user","content":[{"type":"input_image","image_url":"data:image/png;base64,AA=="}]}]}`, true},
+		{`{"input":[{"role":"user","content":"plain string"}]}`, false},
+		{`{"input":[{"type":"computer_call_output","call_id":"c","output":{"type":"computer_screenshot","image_url":"data:image/png;base64,AA=="}}]}`, true},
+		{`{"input":[{"type":"custom_tool_call_output","call_id":"c","output":[{"type":"input_file","file_data":"data:application/pdf;base64,AA=="}]}]}`, true},
+		{`{"input":[{"type":"image_generation_call","id":"ig_1","result":"aGVsbG8="}]}`, true},
+		{`{"input":[{"type":"code_interpreter_call","id":"ci_1","outputs":[{"type":"image","url":"https://example.com/plot.png"}]}]}`, true},
+		{`{"input":[{"type":"code_interpreter_call","id":"ci_1","outputs":[{"type":"logs","logs":"ok"}]}]}`, false},
+	}
+	for i, tc := range cases {
+		if got := codexInputHasMediaParts([]byte(tc.payload)); got != tc.want {
+			t.Fatalf("case %d: got %v, want %v", i, got, tc.want)
+		}
+	}
+}
+
+func TestCountCodexInputTokensRemote(t *testing.T) {
+	var gotPath, gotAuth string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"response.input_tokens","input_tokens":4242}`))
+	}))
+	defer server.Close()
+
+	body := []byte(`{"model":"gpt-5.6-sol","stream":false,"stream_options":{"include_usage":true},"max_output_tokens":16,"service_tier":"priority","temperature":1,"input":[{"type":"message","role":"user","content":[{"type":"input_image","image_url":"data:image/png;base64,AA=="}]}],"tools":[{"type":"function","name":"probe","parameters":{"type":"object","properties":{},"required":[],"additionalProperties":false},"strict":true}]}`)
+	count, err := countCodexInputTokensRemote(context.Background(), nil, nil, "test-key", server.URL, body)
+	if err != nil {
+		t.Fatalf("remote count: %v", err)
+	}
+	if count != 4242 {
+		t.Fatalf("count = %d, want 4242", count)
+	}
+	if gotPath != "/responses/input_tokens" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer test-key" {
+		t.Fatalf("auth header = %q", gotAuth)
+	}
+	for _, path := range []string{"stream", "stream_options", "max_output_tokens", "service_tier", "temperature"} {
+		if gjson.GetBytes(gotBody, path).Exists() {
+			t.Fatalf("create-only field %q must not reach the count endpoint: %s", path, gotBody)
+		}
+	}
+	if gjson.GetBytes(gotBody, "input.0.content.0.type").String() != "input_image" {
+		t.Fatalf("input not forwarded: %s", gotBody)
+	}
+	if gjson.GetBytes(gotBody, "tools.0.name").String() != "probe" {
+		t.Fatalf("tools must be forwarded for accurate counts: %s", gotBody)
+	}
+}
+
+func TestCountCodexInputTokensRemoteUpstreamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"message":"bad schema"}}`))
+	}))
+	defer server.Close()
+	_, err := countCodexInputTokensRemote(context.Background(), nil, nil, "test-key", server.URL, []byte(`{"model":"gpt-5.6-sol","input":[]}`))
+	if err == nil {
+		t.Fatal("want upstream error passthrough")
+	}
+}
+
+func TestCountCodexInputTokensCountsTypelessMessages(t *testing.T) {
+	enc, err := tokenizer.Get(tokenizer.Cl100kBase)
+	if err != nil {
+		t.Fatalf("tokenizer: %v", err)
+	}
+	count, errCount := countCodexInputTokens(enc, []byte(`{"input":[{"role":"user","content":"a longer string body that should be tokenized"},{"role":"user","content":[{"type":"input_text","text":"and array parts too"}]}]}`))
+	if errCount != nil {
+		t.Fatalf("count: %v", errCount)
+	}
+	if count < 12 {
+		t.Fatalf("count = %d, want type-less message content tokenized", count)
+	}
+}
+
+func TestCountTokensNullOptionalFieldsAreInactive(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","prompt":null,"conversation":null,"previous_response_id":null,"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}]}`)
+	for _, path := range []string{"prompt", "conversation", "previous_response_id"} {
+		value := gjson.GetBytes(body, path)
+		if !value.Exists() || value.Type != gjson.Null {
+			t.Fatalf("test payload must carry explicit null for %q", path)
+		}
+	}
+	enc, err := tokenizer.Get(tokenizer.Cl100kBase)
+	if err != nil {
+		t.Fatalf("tokenizer: %v", err)
+	}
+	// Null-inactive fields must keep this on the local path and count fine.
+	count, errCount := countCodexInputTokens(enc, body)
 	if errCount != nil {
 		t.Fatalf("count: %v", errCount)
 	}

--- a/internal/runtime/executor/helps/claude_request_contract.go
+++ b/internal/runtime/executor/helps/claude_request_contract.go
@@ -27,7 +27,7 @@ func ValidateClaudeRequestForCodex(rawJSON []byte) error {
 			for blockIndex, block := range content.Array() {
 				blockType := block.Get("type").String()
 				switch blockType {
-				case "text", "thinking", "redacted_thinking", "tool_use", "compaction", "fallback":
+				case "text", "thinking", "redacted_thinking", "tool_use", "compaction", "fallback", "connector_text":
 				case "server_tool_use":
 					if block.Get("name").String() != "web_search" {
 						return requestContractError("messages.%d.content.%d: unsupported Claude server tool %q for Codex", messageIndex, blockIndex, block.Get("name").String())

--- a/internal/translator/codex/claude/codex_claude_request.go
+++ b/internal/translator/codex/claude/codex_claude_request.go
@@ -170,6 +170,15 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 
 			if messageContentsResult.IsArray() {
 				messageContentResults := messageContentsResult.Array()
+				// Fallback replay contract: connector_text narration before the final
+				// fallback block is model-internal and dropped; after that boundary
+				// (or in turns without fallback) it is ordinary assistant text.
+				lastFallbackIndex := -1
+				for j := 0; j < len(messageContentResults); j++ {
+					if messageContentResults[j].Get("type").String() == "fallback" {
+						lastFallbackIndex = j
+					}
+				}
 				for j := 0; j < len(messageContentResults); j++ {
 					messageContentResult := messageContentResults[j]
 					contentType := messageContentResult.Get("type").String()
@@ -177,8 +186,17 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 					switch contentType {
 					case "text":
 						appendTextContent(messageContentResult.Get("text").String())
+					case "connector_text":
+						if j > lastFallbackIndex {
+							appendTextContent(messageContentResult.Get("text").String())
+						}
 					case "thinking":
-						appendReasoningContent(messageContentResult)
+						// Pre-final-fallback thinking is invalidated by the fallback
+						// contract just like connector_text; only post-boundary
+						// reasoning may replay.
+						if j > lastFallbackIndex {
+							appendReasoningContent(messageContentResult)
+						}
 					case "redacted_thinking", "fallback":
 						// These are model-internal history markers. They must be accepted on
 						// replay but cannot be translated into a valid GPT reasoning signature.
@@ -239,6 +257,11 @@ func ConvertClaudeRequestToCodex(modelName string, inputRawJSON []byte, _ bool) 
 							appendDocumentContent("file_data", fmt.Sprintf("data:%s;base64,%s", claudeMediaType(sourceResult), data), messageContentResult.Get("title").String())
 						}
 					case "tool_use":
+						// Client tool calls before the final fallback block were never
+						// executed; the replay contract drops them.
+						if j < lastFallbackIndex {
+							break
+						}
 						flushMessage()
 						functionCallMessage := []byte(`{"type":"function_call"}`)
 						functionCallMessage, _ = sjson.SetBytes(functionCallMessage, "call_id", shortenCodexCallIDIfNeeded(messageContentResult.Get("id").String()))

--- a/internal/translator/codex/claude/codex_claude_request_test.go
+++ b/internal/translator/codex/claude/codex_claude_request_test.go
@@ -1028,3 +1028,42 @@ func TestConvertClaudeRequestToCodex_ExplicitEffortSurvivesWithoutThinking(t *te
 		}
 	}
 }
+
+func TestConvertClaudeRequestToCodex_ConnectorTextFallbackBoundary(t *testing.T) {
+	input := []byte(`{
+		"model":"claude-fable-5",
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"connector_text","text":"pre-fallback narration"},
+				{"type":"tool_use","id":"call_dropped","name":"never_ran","input":{}},
+				{"type":"fallback","from":{"model":"claude-fable-5"},"to":{"model":"claude-opus-4-8"}},
+				{"type":"connector_text","text":"post-fallback narration"},
+				{"type":"text","text":"answer"}
+			]},
+			{"role":"user","content":"continue"}
+		]
+	}`)
+	result := gjson.ParseBytes(ConvertClaudeRequestToCodex("gpt-5.6-sol", input, false))
+	flat := result.Get("input").Raw
+	if strings.Contains(flat, "pre-fallback narration") {
+		t.Fatalf("pre-fallback connector_text must be dropped: %s", flat)
+	}
+	if strings.Contains(flat, "call_dropped") {
+		t.Fatalf("pre-fallback client tool_use must be dropped: %s", flat)
+	}
+	if !strings.Contains(flat, "post-fallback narration") {
+		t.Fatalf("post-fallback connector_text must be retained: %s", flat)
+	}
+	// Without any fallback block, narration between tool calls is ordinary text.
+	plain := []byte(`{
+		"model":"claude-fable-5",
+		"messages":[
+			{"role":"assistant","content":[{"type":"connector_text","text":"between tool calls"}]},
+			{"role":"user","content":"continue"}
+		]
+	}`)
+	result = gjson.ParseBytes(ConvertClaudeRequestToCodex("gpt-5.6-sol", plain, false))
+	if !strings.Contains(result.Get("input").Raw, "between tool calls") {
+		t.Fatalf("connector_text without fallback must be retained: %s", result.Get("input").Raw)
+	}
+}

--- a/internal/translator/gemini/claude/gemini_claude_request.go
+++ b/internal/translator/gemini/claude/gemini_claude_request.go
@@ -128,15 +128,19 @@ func ConvertClaudeRequestToGemini(modelName string, inputRawJSON []byte, _ bool)
 						}
 						funcName = util.SanitizeFunctionName(funcName)
 						toolResult := util.ConvertClaudeToolResult(contentResult)
-						part := []byte(`{"functionResponse":{"name":"","response":{"result":""}}}`)
+						part := []byte(`{"functionResponse":{"name":"","response":{}}}`)
 						part, _ = sjson.SetBytes(part, "functionResponse.name", funcName)
-						if toolResult.ResultIsRaw {
-							part, _ = sjson.SetRawBytes(part, "functionResponse.response.result", []byte(toolResult.Result))
-						} else {
-							part, _ = sjson.SetBytes(part, "functionResponse.response.result", toolResult.Result)
-						}
+						// FunctionResponse contract: "error" carries error details and, once
+						// present, other response keys stop being treated as output — so a
+						// failed tool result must put its content under "error", not beside it.
+						resultPath := "functionResponse.response.result"
 						if toolResult.IsError {
-							part, _ = sjson.SetBytes(part, "functionResponse.response.error", true)
+							resultPath = "functionResponse.response.error"
+						}
+						if toolResult.ResultIsRaw {
+							part, _ = sjson.SetRawBytes(part, resultPath, []byte(toolResult.Result))
+						} else {
+							part, _ = sjson.SetBytes(part, resultPath, toolResult.Result)
 						}
 						partItems = append(partItems, part)
 						for _, img := range toolResult.Images {

--- a/internal/translator/gemini/claude/gemini_claude_request_test.go
+++ b/internal/translator/gemini/claude/gemini_claude_request_test.go
@@ -235,11 +235,13 @@ func TestConvertClaudeRequestToGemini_ErrorToolResultPreservesRawResult(t *testi
 	}`)
 	output := ConvertClaudeRequestToGemini("gemini-3-flash-preview", inputJSON, false)
 	response := gjson.GetBytes(output, "contents.1.parts.0.functionResponse.response")
-	if response.Get("result.error").String() != "timeout" || !response.Get("result.retryable").Bool() {
-		t.Fatalf("raw result changed: %s", response.Raw)
+	// Error results route through the contract's "error" key; a sibling
+	// "result" would stop counting as output once "error" is present.
+	if response.Get("error.error").String() != "timeout" || !response.Get("error.retryable").Bool() {
+		t.Fatalf("error payload not in error channel: %s", response.Raw)
 	}
-	if !response.Get("error").Bool() {
-		t.Fatalf("error marker missing: %s", response.Raw)
+	if response.Get("result").Exists() {
+		t.Fatalf("failed tool result must not keep a result key: %s", response.Raw)
 	}
 }
 


### PR DESCRIPTION
## What

Resolves the three follow-ups consciously deferred in #3:

1. **Exact media/stateful token counting.** `count_tokens` requests carrying media (message/tool-output parts, computer screenshots, code-interpreter image outputs, image-generation results) or server-side history (`conversation`, `previous_response_id`) now route through `POST {base}/responses/input_tokens` for an exact provider count, instead of failing request-scoped. The remote payload is projected onto the endpoint's supported fields; standard Codex credential/header injection is reused. ChatGPT-backend auths (no platform base URL) and reusable `prompt` templates stay fail-closed, since neither has a countable path. Nullable fields are null-aware.
2. **Fallback replay boundary.** Per the refusals-and-fallback contract: `connector_text` now validates; narration, `thinking`, and client `tool_use` before the final `fallback` block are dropped; post-boundary blocks replay normally.
3. **Gemini error channel.** Failed tool results put their content under the `functionResponse.response.error` key per the FunctionResponse contract. The previous `error: true` beside `result` actually suppressed the output channel entirely.

## Evidence

- Full `go build ./... && go test ./...` green.
- Live proof against api.openai.com with the gorillaclaw gateway credential: image payload → 200, `input_tokens: 9`; instructions + strict tools + inline PDF → 200, `input_tokens: 63`.
- Contracts cited from the official openai-python SDK (input_tokens/prompt schemas), google go-genai `FunctionResponse`, and the Anthropic refusals-and-fallback doc.
- Nine autoreview rounds (Codex gpt-5.6-sol, xhigh); final round clean at 0.94 with every prior finding fixed.
