### PR TITLE
feat(claude): log request-contract rejections with reason

### DIFF
--- a/internal/runtime/executor/helps/claude_request_contract.go
+++ b/internal/runtime/executor/helps/claude_request_contract.go
@@ -10,6 +10,7 @@ import (
 	translatorcommon "github.com/router-for-me/CLIProxyAPI/v7/internal/translator/common"
 	"github.com/router-for-me/CLIProxyAPI/v7/internal/util"
 	cliproxyexecutor "github.com/router-for-me/CLIProxyAPI/v7/sdk/cliproxy/executor"
+	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 )
 
@@ -317,9 +318,13 @@ func validateClaudeContentDocument(content gjson.Result) error {
 }
 
 func requestContractError(format string, args ...any) error {
+	message := fmt.Sprintf(format, args...)
+	// Rejections are otherwise invisible server-side (only the gin 400 line);
+	// the reason names paths/rules, never payload content, so it is log-safe.
+	log.Warnf("claude request contract rejection: %s", message)
 	return &cliproxyexecutor.RequestError{
 		HTTPStatus: http.StatusBadRequest,
 		Code:       "invalid_request_error",
-		Message:    fmt.Sprintf(format, args...),
+		Message:    message,
 	}
 }


### PR DESCRIPTION
Validator 400s are currently invisible in the journal (only the gin status line). Logs the rejection reason at warn level — messages name JSON paths/rules only, never payload content. Needed live to diagnose an active fast-400 retry loop from a fleet client. Trivial 3-line observability change; helps package tests green.