### PR TITLE
fix(codex): recover complete output after stream EOF

### DIFF
--- a/internal/runtime/executor/codex_executor_execute.go
+++ b/internal/runtime/executor/codex_executor_execute.go
@@ -133,8 +133,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 	helps.AppendAPIResponseChunk(ctx, e.cfg, upstreamData)
 
 	lines := bytes.Split(upstreamData, []byte("\n"))
-	outputItemsByIndex := make(map[int64][]byte)
-	var outputItemsFallback [][]byte
+	recovery := newCodexStreamTerminalRecovery()
 	for _, line := range lines {
 		if !bytes.HasPrefix(line, dataTag) {
 			continue
@@ -143,6 +142,7 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		eventData := bytes.TrimSpace(line[5:])
 		eventData = helps.RestoreCodexMultiAgentV2Response(eventData, optimizeMultiAgentV2)
 		eventType := gjson.GetBytes(eventData, "type").String()
+		recovery.observe(eventData)
 
 		if streamErr, terminalBody, ok := codexTerminalFailureErr(eventData); ok {
 			if errClearReplay := clearCodexReasoningReplayOnInvalidSignature(ctx, replayScope, streamErr.StatusCode(), terminalBody); errClearReplay != nil {
@@ -153,16 +153,6 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		}
 
 		if eventType == "response.output_item.done" {
-			itemResult := gjson.GetBytes(eventData, "item")
-			if !itemResult.Exists() || itemResult.Type != gjson.JSON {
-				continue
-			}
-			outputIndexResult := gjson.GetBytes(eventData, "output_index")
-			if outputIndexResult.Exists() {
-				outputItemsByIndex[outputIndexResult.Int()] = []byte(itemResult.Raw)
-			} else {
-				outputItemsFallback = append(outputItemsFallback, []byte(itemResult.Raw))
-			}
 			continue
 		}
 
@@ -175,11 +165,19 @@ func (e *CodexExecutor) Execute(ctx context.Context, auth *cliproxyauth.Auth, re
 		}
 		publishCodexImageToolUsage(ctx, reporter, body, eventData)
 
-		completedData := patchCodexCompletedOutput(eventData, outputItemsByIndex, outputItemsFallback)
+		completedData := patchCodexCompletedOutput(eventData, recovery.outputItemsByIndex, recovery.outputItemsFallback)
 		if eventType == "response.completed" {
 			cacheCodexReasoningReplayFromCompleted(replayScope, completedData)
 		}
 
+		var param any
+		clientCompletedData := applyCodexIdentityExposeResponsePayload(completedData, identityState)
+		out := sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, originalPayload, body, clientCompletedData, &param)
+		resp = cliproxyexecutor.Response{Payload: out, Headers: httpResp.Header.Clone()}
+		return resp, nil
+	}
+	if completedData, ok := recovery.completedEvent(); ok {
+		helps.LogWithRequestID(ctx).Warn("codex executor: recovered complete output after upstream closed before response.completed")
 		var param any
 		clientCompletedData := applyCodexIdentityExposeResponsePayload(completedData, identityState)
 		out := sdktranslator.TranslateNonStream(ctx, to, responseFormat, req.Model, originalPayload, body, clientCompletedData, &param)

--- a/internal/runtime/executor/codex_executor_stream.go
+++ b/internal/runtime/executor/codex_executor_stream.go
@@ -158,8 +158,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 		scanner.Buffer(nil, 52_428_800) // 50MB
 		claudeInputTokens := helps.NewClaudeInputTokenState(from, to, responseFormat, originalPayload)
 		var param any
-		outputItemsByIndex := make(map[int64][]byte)
-		var outputItemsFallback [][]byte
+		recovery := newCodexStreamTerminalRecovery()
 		for scanner.Scan() {
 			line := applyCodexIdentityConfuseResponsePayload(scanner.Bytes(), identityState)
 			helps.AppendAPIResponseChunk(ctx, e.cfg, line)
@@ -169,6 +168,7 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			if bytes.HasPrefix(line, dataTag) {
 				data := bytes.TrimSpace(line[5:])
 				data = helps.RestoreCodexMultiAgentV2Response(data, optimizeMultiAgentV2)
+				recovery.observe(data)
 				translatedLine = append([]byte("data: "), data...)
 				eventType := gjson.GetBytes(data, "type").String()
 				if streamErr, terminalBody, ok := codexTerminalFailureErr(data); ok {
@@ -190,15 +190,13 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 					return
 				}
 				switch eventType {
-				case "response.output_item.done":
-					collectCodexOutputItemDone(data, outputItemsByIndex, &outputItemsFallback)
 				case "response.completed", "response.incomplete":
 					terminalSuccess = true
 					if detail, ok := helps.ParseCodexUsage(data); ok {
 						reporter.Publish(ctx, detail)
 					}
 					publishCodexImageToolUsage(ctx, reporter, body, data)
-					data = patchCodexCompletedOutput(data, outputItemsByIndex, outputItemsFallback)
+					data = patchCodexCompletedOutput(data, recovery.outputItemsByIndex, recovery.outputItemsFallback)
 					if eventType == "response.completed" {
 						cacheCodexReasoningReplayFromCompleted(replayScope, data)
 					}
@@ -218,6 +216,20 @@ func (e *CodexExecutor) ExecuteStream(ctx context.Context, auth *cliproxyauth.Au
 			if terminalSuccess {
 				return
 			}
+		}
+		if completedData, ok := recovery.completedEvent(); ok {
+			helps.LogWithRequestID(ctx).Warn("codex executor: recovered complete output after upstream closed before response.completed")
+			translatedLine := append([]byte("data: "), completedData...)
+			translatedLine = applyCodexIdentityExposeResponsePayload(translatedLine, identityState)
+			chunks := helps.TranslateStreamWithClaudeInputTokens(ctx, to, responseFormat, req.Model, originalPayload, body, translatedLine, &param, claudeInputTokens)
+			for i := range chunks {
+				select {
+				case out <- cliproxyexecutor.StreamChunk{Payload: chunks[i]}:
+				case <-ctx.Done():
+					return
+				}
+			}
+			return
 		}
 		if errScan := scanner.Err(); errScan != nil {
 			if ctx.Err() != nil {

--- a/internal/runtime/executor/codex_executor_stream_output_test.go
+++ b/internal/runtime/executor/codex_executor_stream_output_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -246,6 +247,133 @@ func TestCodexExecutorExecuteStreamMissingCompletionIsRequestScoped(t *testing.T
 		t.Fatalf("status code = %d, want %d; err=%v", got, http.StatusRequestTimeout, streamErr)
 	}
 	assertRequestScopedTestError(t, streamErr)
+}
+
+func TestCodexExecutorExecuteStreamRecoversCompletedToolCallOnEOF(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5.6-sol","status":"in_progress"}}` + "\n\n"))
+		_, _ = w.Write([]byte(`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"Read","arguments":"","status":"in_progress"}}` + "\n\n"))
+		_, _ = w.Write([]byte(`data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"Read","arguments":"{\"file_path\":\"a.txt\"}","status":"completed"}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.6-sol",
+		Payload: []byte(`{"model":"gpt-5.6-sol","input":"read a.txt"}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("openai-response"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	completedCount := 0
+	var recovered []byte
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		payload := bytes.TrimSpace(chunk.Payload)
+		if !bytes.HasPrefix(payload, []byte("data:")) {
+			continue
+		}
+		data := bytes.TrimSpace(payload[5:])
+		if gjson.GetBytes(data, "type").String() == "response.completed" {
+			completedCount++
+			recovered = bytes.Clone(data)
+		}
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("upstream calls = %d, want 1", got)
+	}
+	if completedCount != 1 {
+		t.Fatalf("response.completed count = %d, want 1", completedCount)
+	}
+	if got := gjson.GetBytes(recovered, "response.output.0.call_id").String(); got != "call_1" {
+		t.Fatalf("recovered call_id = %q, want call_1; payload=%s", got, recovered)
+	}
+	if got := gjson.GetBytes(recovered, "response.status").String(); got != "completed" {
+		t.Fatalf("recovered status = %q, want completed; payload=%s", got, recovered)
+	}
+}
+
+func TestCodexExecutorExecuteStreamRecoveredToolCallTerminatesClaudeOnce(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5.6-sol","status":"in_progress"}}` + "\n\n"))
+		_, _ = w.Write([]byte(`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"Read","arguments":"","status":"in_progress"}}` + "\n\n"))
+		_, _ = w.Write([]byte(`data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"Read","arguments":"{\"file_path\":\"a.txt\"}","status":"completed"}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	executor := NewCodexExecutor(&config.Config{})
+	auth := &cliproxyauth.Auth{Attributes: map[string]string{
+		"base_url": server.URL,
+		"api_key":  "test",
+	}}
+
+	result, err := executor.ExecuteStream(context.Background(), auth, cliproxyexecutor.Request{
+		Model:   "gpt-5.6-sol",
+		Payload: []byte(`{"model":"gpt-5.6-sol","max_tokens":64,"messages":[{"role":"user","content":"read a.txt"}]}`),
+	}, cliproxyexecutor.Options{
+		SourceFormat: sdktranslator.FromString("claude"),
+		Stream:       true,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteStream error: %v", err)
+	}
+
+	var stream bytes.Buffer
+	for chunk := range result.Chunks {
+		if chunk.Err != nil {
+			t.Fatalf("stream chunk error: %v", chunk.Err)
+		}
+		stream.Write(chunk.Payload)
+		stream.WriteByte('\n')
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("upstream calls = %d, want 1", got)
+	}
+	if got := strings.Count(stream.String(), "event: message_stop"); got != 1 {
+		t.Fatalf("message_stop count = %d, want 1; stream=%s", got, stream.String())
+	}
+	if got := strings.Count(stream.String(), `"type":"tool_use"`); got != 1 {
+		t.Fatalf("tool_use count = %d, want 1; stream=%s", got, stream.String())
+	}
+}
+
+func TestCodexStreamTerminalRecoveryRejectsUnfinishedOutput(t *testing.T) {
+	recovery := newCodexStreamTerminalRecovery()
+	recovery.observe([]byte(`{"type":"response.created","response":{"id":"resp_1","status":"in_progress"}}`))
+	recovery.observe([]byte(`{"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","status":"in_progress"}}`))
+
+	if completed, ok := recovery.completedEvent(); ok {
+		t.Fatalf("unfinished output unexpectedly recovered: %s", completed)
+	}
+}
+
+func TestCodexStreamTerminalRecoveryRequiresActionableOutput(t *testing.T) {
+	recovery := newCodexStreamTerminalRecovery()
+	recovery.observe([]byte(`{"type":"response.created","response":{"id":"resp_1","status":"in_progress"}}`))
+	recovery.observe([]byte(`{"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","status":"completed","summary":[]}}`))
+
+	if completed, ok := recovery.completedEvent(); ok {
+		t.Fatalf("reasoning-only output unexpectedly recovered: %s", completed)
+	}
 }
 
 func TestCodexExecutorExecuteStreamExplicitTerminalFailureIsNotSuccessful(t *testing.T) {

--- a/internal/runtime/executor/codex_executor_terminal.go
+++ b/internal/runtime/executor/codex_executor_terminal.go
@@ -18,6 +18,91 @@ type codexIncompleteStreamError struct {
 	statusErr
 }
 
+type codexStreamTerminalRecovery struct {
+	openFallback        int
+	openItemsByIndex    map[int64]struct{}
+	outputItemsByIndex  map[int64][]byte
+	outputItemsFallback [][]byte
+	responseCreated     []byte
+}
+
+func newCodexStreamTerminalRecovery() *codexStreamTerminalRecovery {
+	return &codexStreamTerminalRecovery{
+		openItemsByIndex:   make(map[int64]struct{}),
+		outputItemsByIndex: make(map[int64][]byte),
+	}
+}
+
+func (r *codexStreamTerminalRecovery) observe(eventData []byte) {
+	switch gjson.GetBytes(eventData, "type").String() {
+	case "response.created":
+		response := gjson.GetBytes(eventData, "response")
+		if response.Exists() && response.Type == gjson.JSON {
+			r.responseCreated = []byte(response.Raw)
+		}
+	case "response.output_item.added":
+		if outputIndex := gjson.GetBytes(eventData, "output_index"); outputIndex.Exists() {
+			r.openItemsByIndex[outputIndex.Int()] = struct{}{}
+		} else {
+			r.openFallback++
+		}
+	case "response.output_item.done":
+		if outputIndex := gjson.GetBytes(eventData, "output_index"); outputIndex.Exists() {
+			delete(r.openItemsByIndex, outputIndex.Int())
+		} else if r.openFallback > 0 {
+			r.openFallback--
+		}
+		collectCodexOutputItemDone(eventData, r.outputItemsByIndex, &r.outputItemsFallback)
+	}
+}
+
+func (r *codexStreamTerminalRecovery) completedEvent() ([]byte, bool) {
+	if len(r.responseCreated) == 0 || len(r.openItemsByIndex) > 0 || r.openFallback > 0 {
+		return nil, false
+	}
+
+	hasActionableOutput := false
+	for _, item := range r.outputItemsByIndex {
+		if !codexOutputItemSafeForTerminalRecovery(item) {
+			return nil, false
+		}
+		if codexOutputItemActionable(item) {
+			hasActionableOutput = true
+		}
+	}
+	for _, item := range r.outputItemsFallback {
+		if !codexOutputItemSafeForTerminalRecovery(item) {
+			return nil, false
+		}
+		if codexOutputItemActionable(item) {
+			hasActionableOutput = true
+		}
+	}
+	if !hasActionableOutput {
+		return nil, false
+	}
+
+	completed := []byte(`{"type":"response.completed","sequence_number":0,"response":{}}`)
+	completed, _ = sjson.SetRawBytes(completed, "response", r.responseCreated)
+	completed, _ = sjson.SetBytes(completed, "response.status", "completed")
+	completed, _ = sjson.SetRawBytes(completed, "response.error", []byte("null"))
+	return patchCodexCompletedOutput(completed, r.outputItemsByIndex, r.outputItemsFallback), true
+}
+
+func codexOutputItemSafeForTerminalRecovery(item []byte) bool {
+	status := strings.TrimSpace(gjson.GetBytes(item, "status").String())
+	return status == "" || status == "completed"
+}
+
+func codexOutputItemActionable(item []byte) bool {
+	switch gjson.GetBytes(item, "type").String() {
+	case "message", "function_call", "custom_tool_call":
+		return true
+	default:
+		return false
+	}
+}
+
 func newCodexIncompleteStreamError() codexIncompleteStreamError {
 	return codexIncompleteStreamError{statusErr: statusErr{
 		code: http.StatusRequestTimeout,


### PR DESCRIPTION
## Summary

- recover a missing terminal event only when every observed output item is complete
- synthesize exactly one completion event without replaying the upstream request
- preserve explicit errors for unfinished or reasoning-only streams

## Proof

- `go test ./internal/runtime/executor -count=1`
- `go build -o /tmp/cliproxy-autoreview-build ./cmd/server`
- focused tests prove one upstream call, one downstream tool call, and one message stop

The full suite has one unrelated existing WebRTC media test failure on this Mac; the exact test fails unchanged when run alone.
